### PR TITLE
poc: vector artifacts behind a config flag + windowed continuous scoring

### DIFF
--- a/benchmarks/poc/README.md
+++ b/benchmarks/poc/README.md
@@ -158,6 +158,27 @@ pair_report.sh <honest-model> <fraud-model> runs/pairAB --profile cudagraph --ur
 Measured (100 samples, AWQ vs w8a16, cudagraph): honest **0.14%** / fraud **33.8%** →
 clean separation.
 
+### Vector channel (continuous, next to the k-mismatch rate)
+The sphere_k snap keeps ~4 bits/step, so a subtle fraud sits only a few pp above
+the honest cross-HW flip floor (A100: AWQ 9.5% vs floor ~7% cross-HW — under the
+fixed `p_mismatch=0.1` it slips through). The pre-snap slices carry the full
+displacement field: collect with `--debug` on BOTH sides and the validation
+response gains a `vector_score` (per-nonce mean cosine distance between prover
+and validator slices; the k-based verdict is unchanged — evidence for A/B).
+
+```bash
+collect.py --mode generate --model <honest> --debug --save gen_h.json --url $S
+collect.py --mode generate --model <fraud>  --debug --save gen_f.json --url $S
+collect.py --mode validate --model <honest> --debug --ref gen_h.json --save val_h.json --url $S
+collect.py --mode validate --model <honest> --debug --ref gen_f.json --save val_f.json --url $S
+vector_separation.py gen_h.json:val_h.json gen_f.json:val_f.json   # offline table
+```
+Measured (A100, MiniMax-M2.7 FP8 vs AWQ, 32 nonces × 256 steps): honest floor
+**9e-5**, honest cross-engine **3.5e-4**, fraud **5.5e-3** → fraud/floor 60×,
+no per-nonce overlap (worst honest 8.8e-4 < weakest fraud 3.0e-3), AUC 1.0,
+K=9 nonces — on the same trajectories where the k-rate misses at p_mismatch=0.1.
+Artifact cost: ~512 B/step fp16 (D=256); prefill keeps the legacy `vector_b64`.
+
 ## Test 2 — co-existence (GSM8K)
 A **separate** question from separation: does running PoC alongside real user inference
 degrade answer quality? Run GSM8K twice — once with PoC load, once without — and compare

--- a/benchmarks/poc/README.md
+++ b/benchmarks/poc/README.md
@@ -179,6 +179,21 @@ no per-nonce overlap (worst honest 8.8e-4 < weakest fraud 3.0e-3), AUC 1.0,
 K=9 nonces — on the same trajectories where the k-rate misses at p_mismatch=0.1.
 Artifact cost: ~512 B/step fp16 (D=256); prefill keeps the legacy `vector_b64`.
 
+### Per-nonce reflection seeding (opt-in)
+By default every nonce of a block reflects with ONE Householder draw seeded by
+block_hash — the whole block shares a single measurement instrument, so the
+draw's own bias is a common term that block averaging cannot remove. With
+`--per-nonce-reflection` on **generate**, vectors are seeded by
+(block_hash, nonce): each nonce measures with an independent draw and the
+block statistic averages the draw noise away with 1/n like the nonce noise.
+Forward-affecting: validate replays the mode from the reference meta
+automatically — never set it by hand on validate.
+
+```bash
+collect.py --mode generate --model <honest> --debug --per-nonce-reflection --save gen_h.json --url $S
+collect.py --mode validate --model <honest> --debug --ref gen_h.json --save val_h.json --url $S
+```
+
 ## Test 2 — co-existence (GSM8K)
 A **separate** question from separation: does running PoC alongside real user inference
 degrade answer quality? Run GSM8K twice — once with PoC load, once without — and compare

--- a/benchmarks/poc/collect.py
+++ b/benchmarks/poc/collect.py
@@ -38,7 +38,7 @@ def cmd_generate(a):
     with deploy_from_args(a, a.model) as (url, srv):
         resp, secs = request_generate(url, target=a.target, model=a.model, nonces=nonces,
                                       block_hash=BH, public_key=PK, seq_len=a.seq_len,
-                                      max_tokens=a.max_tokens, k_dim=KDIM)
+                                      max_tokens=a.max_tokens, k_dim=KDIM, debug=a.debug)
     arts = resp["artifacts"]
     nps = len(nonces) / secs if secs else 0.0
     meta = {"role": "generate", "model": a.model, "seq_len": a.seq_len,
@@ -59,10 +59,12 @@ def cmd_validate(a):
         resp, secs = request_generate(url, target=a.target, model=a.model, nonces=nonces,
                                       block_hash=rmeta["block_hash"], public_key=rmeta["public_key"],
                                       seq_len=seq, max_tokens=mt, k_dim=rmeta["k_dim"],
-                                      enforced_k=enforced, validation=ref_arts, p_mismatch=a.p_mismatch)
+                                      enforced_k=enforced, validation=ref_arts,
+                                      p_mismatch=a.p_mismatch, debug=a.debug)
     rate = resp["n_mismatch"] / (len(nonces) * (mt + 1))
     nps = len(nonces) / secs if secs else 0.0
     honest = a.model == rmeta["model"]
+    vec = resp.get("vector_score")  # present when ref was generated with --debug too
     meta = {"role": "validate", "validator_model": a.model, "prover_model": rmeta["model"],
             "seq_len": seq, "max_tokens": mt, "k_dim": rmeta["k_dim"], "block_hash": rmeta["block_hash"],
             "public_key": rmeta["public_key"], "codebook_hash": rmeta.get("codebook_hash", CODEBOOK_HASH),
@@ -73,10 +75,12 @@ def cmd_validate(a):
              results={"validator_model": a.model, "prover_model": rmeta["model"], "honest": honest,
                       "rate": rate, "n_mismatch": resp["n_mismatch"], "fraud_detected": resp["fraud_detected"],
                       "per_nonce": resp.get("per_nonce", []),  # per-nonce mismatch counts (for charts)
+                      "vector_score": vec,  # continuous channel (needs --debug both sides)
                       "prover_gpu": rmeta.get("gpu"),  # prover HW (this run is the validator's HW)
                       "nonces_per_s": round(nps, 3), "elapsed_s": round(secs, 1)})
+    vtxt = f" vec_mean_dist={vec['mean_dist']:.2e}" if vec else ""
     print(f"validate {a.model} vs ref {rmeta['model']} ({'honest' if honest else 'fraud'}): "
-          f"rate={rate*100:.3f}% fraud={resp['fraud_detected']} {nps:.2f} nonces/s -> {a.save}")
+          f"rate={rate*100:.3f}% fraud={resp['fraud_detected']}{vtxt} {nps:.2f} nonces/s -> {a.save}")
 
 
 def main():
@@ -95,6 +99,10 @@ def main():
     ap.add_argument("--seq-len", type=int, default=256)
     ap.add_argument("--max-tokens", type=int, default=256)
     ap.add_argument("--p-mismatch", type=float, default=0.1)
+    # artifacts also carry per-step pre-snap sphere slices (sph_values_steps).
+    # Generate refs with --debug AND validate with --debug to get the continuous
+    # vector-channel score (vector_score) next to the k-mismatch rate.
+    ap.add_argument("--debug", action="store_true")
     ap.add_argument("--save", required=True)
     a = ap.parse_args()
     if a.mode == "validate" and not a.ref:

--- a/benchmarks/poc/collect.py
+++ b/benchmarks/poc/collect.py
@@ -81,7 +81,8 @@ def cmd_validate(a):
              results={"validator_model": a.model, "prover_model": rmeta["model"], "honest": honest,
                       "rate": rate, "n_mismatch": resp["n_mismatch"], "fraud_detected": resp["fraud_detected"],
                       "per_nonce": resp.get("per_nonce", []),  # per-nonce mismatch counts (for charts)
-                      "vector_score": vec,  # continuous channel (needs --debug both sides)
+                      # continuous channel (vectors present on both sides)
+                      "vector_score": vec,
                       "prover_gpu": rmeta.get("gpu"),  # prover HW (this run is the validator's HW)
                       "nonces_per_s": round(nps, 3), "elapsed_s": round(secs, 1)})
     vtxt = f" vec_mean_dist={vec['mean_dist']:.2e}" if vec else ""

--- a/benchmarks/poc/collect.py
+++ b/benchmarks/poc/collect.py
@@ -38,12 +38,14 @@ def cmd_generate(a):
     with deploy_from_args(a, a.model) as (url, srv):
         resp, secs = request_generate(url, target=a.target, model=a.model, nonces=nonces,
                                       block_hash=BH, public_key=PK, seq_len=a.seq_len,
-                                      max_tokens=a.max_tokens, k_dim=KDIM, debug=a.debug)
+                                      max_tokens=a.max_tokens, k_dim=KDIM, debug=a.debug,
+                                      per_nonce_reflection=a.per_nonce_reflection)
     arts = resp["artifacts"]
     nps = len(nonces) / secs if secs else 0.0
     meta = {"role": "generate", "model": a.model, "seq_len": a.seq_len,
             "max_tokens": a.max_tokens, "k_dim": KDIM, "block_hash": BH, "public_key": PK,
-            "codebook_hash": CODEBOOK_HASH, "nonces": nonces, "batch_size": 32, **a.prov}
+            "codebook_hash": CODEBOOK_HASH, "nonces": nonces, "batch_size": 32,
+            "per_nonce_reflection": a.per_nonce_reflection, **a.prov}
     save_run(a.save, meta, arts,
              results={"nonces_per_s": round(nps, 3), "steps_per_s": round(nps * (a.max_tokens + 1), 1),
                       "elapsed_s": round(secs, 1)})
@@ -55,12 +57,16 @@ def cmd_validate(a):
     rmeta, ref_arts = load_run(a.ref)
     nonces, mt, seq = rmeta["nonces"], rmeta["max_tokens"], rmeta["seq_len"]
     enforced = {x["nonce"]: x["k_points_steps"] for x in ref_arts}
+    # Replay the reference's reflection-seeding mode: forward-affecting, so the
+    # validator MUST run the same scheme the artifacts were generated with.
+    pnr = bool(rmeta.get("per_nonce_reflection", False))
     with deploy_from_args(a, a.model) as (url, srv):
         resp, secs = request_generate(url, target=a.target, model=a.model, nonces=nonces,
                                       block_hash=rmeta["block_hash"], public_key=rmeta["public_key"],
                                       seq_len=seq, max_tokens=mt, k_dim=rmeta["k_dim"],
                                       enforced_k=enforced, validation=ref_arts,
-                                      p_mismatch=a.p_mismatch, debug=a.debug)
+                                      p_mismatch=a.p_mismatch, debug=a.debug,
+                                      per_nonce_reflection=pnr)
     rate = resp["n_mismatch"] / (len(nonces) * (mt + 1))
     nps = len(nonces) / secs if secs else 0.0
     honest = a.model == rmeta["model"]
@@ -103,6 +109,11 @@ def main():
     # Generate refs with --debug AND validate with --debug to get the continuous
     # vector-channel score (vector_score) next to the k-mismatch rate.
     ap.add_argument("--debug", action="store_true")
+    # generate-only: seed the Householder reflections per (block_hash, nonce)
+    # instead of per block_hash (each nonce = its own independent draw). validate
+    # replays the mode from the reference meta automatically — never set by hand
+    # on validate (a mismatch diverges every chain).
+    ap.add_argument("--per-nonce-reflection", action="store_true")
     ap.add_argument("--save", required=True)
     a = ap.parse_args()
     if a.mode == "validate" and not a.ref:

--- a/benchmarks/poc/poc_validation.py
+++ b/benchmarks/poc/poc_validation.py
@@ -286,6 +286,7 @@ def request_generate(
     fraud_threshold: float = 0.01,
     wait: bool = True,
     timeout: int = 900,
+    debug: bool = False,
 ):
     """The one v2 /generate request builder. Returns (response_json, elapsed_sec).
 
@@ -293,6 +294,8 @@ def request_generate(
     - raw validation:     pass enforced_k -> artifacts carry n_sphere_mismatches.
     - verdict validation: pass enforced_k + validation -> run_validation runs and
       returns fraud_detected. max_tokens>0 selects the decode trajectory metric.
+    - debug=True: artifacts additionally carry the per-step pre-snap sphere slices
+      (sph_values_steps) — needed for the vector-channel score / offline analysis.
     """
     payload: Dict[str, Any] = {
         "block_hash": block_hash, "block_height": 100, "public_key": public_key,
@@ -300,6 +303,8 @@ def request_generate(
         "params": {"model": model, "seq_len": seq_len, "k_dim": k_dim, "max_tokens": max_tokens},
         "batch_size": batch_size, "wait": wait,
     }
+    if debug:
+        payload["debug"] = True
     if enforced_k is not None:
         payload["enforced_k_steps"] = enforced_k
     if validation is not None:

--- a/benchmarks/poc/poc_validation.py
+++ b/benchmarks/poc/poc_validation.py
@@ -287,6 +287,7 @@ def request_generate(
     wait: bool = True,
     timeout: int = 900,
     debug: bool = False,
+    per_nonce_reflection: bool = False,
 ):
     """The one v2 /generate request builder. Returns (response_json, elapsed_sec).
 
@@ -296,6 +297,9 @@ def request_generate(
       returns fraud_detected. max_tokens>0 selects the decode trajectory metric.
     - debug=True: artifacts additionally carry the per-step pre-snap sphere slices
       (sph_values_steps) — needed for the vector-channel score / offline analysis.
+    - per_nonce_reflection=True: Householder reflections seeded per (block_hash,
+      nonce) instead of per block_hash. Forward-affecting — a validation request
+      must match the reference generation's setting.
     """
     payload: Dict[str, Any] = {
         "block_hash": block_hash, "block_height": 100, "public_key": public_key,
@@ -305,6 +309,8 @@ def request_generate(
     }
     if debug:
         payload["debug"] = True
+    if per_nonce_reflection:
+        payload["per_nonce_reflection"] = True
     if enforced_k is not None:
         payload["enforced_k_steps"] = enforced_k
     if validation is not None:

--- a/benchmarks/poc/scope/setup_box.sh
+++ b/benchmarks/poc/scope/setup_box.sh
@@ -55,6 +55,25 @@ find vllm \( -name '*.py' -o -name '*.pt' \) -printf '%P\n' | while read f; do
   install -D -m644 "vllm/$f" "$SP/$f"
 done
 
+echo "== 3b. patch the cute-FA arch gate (unblocks FLASH_ATTN on B300/sm_103) =="
+# The wheel's cute FA kernel gates on `Arch.sm_100 <= arch <= Arch.sm_110f`
+# ("Only SM 10.x and 11.x"), but the vendored nvidia-cutlass-dsl enum maps
+# sm_110f=(10,1,'f') — so the gate really means SM 10.0–10.1 and rejects
+# B300 (sm_103), which the kernel itself supports (it has an is_sm103 branch;
+# patched FA validates bit-exact against itself on B300). Rewrite the gate to
+# the check its own message claims. Idempotent.
+FA_FWD="$SP/vllm_flash_attn/cute/flash_fwd_sm100.py"
+if [ -f "$FA_FWD" ] && grep -q 'self.arch >= Arch.sm_100 and self.arch <= Arch.sm_110f' "$FA_FWD"; then
+  sed -i 's|assert self.arch >= Arch.sm_100 and self.arch <= Arch.sm_110f, "Only SM 10.x and 11.x are supported"|assert self.arch.major in (10, 11), "Only SM 10.x and 11.x are supported"  # patched by setup_box: vendored cutlass maps sm_110f=(10,1), excluding sm_103/B300|' "$FA_FWD"
+  grep -q 'patched by setup_box' "$FA_FWD" || { echo "FATAL: FA gate substitution did not apply" >&2; exit 4; }
+  echo "   patched $FA_FWD"
+elif [ -f "$FA_FWD" ] && grep -q 'patched by setup_box' "$FA_FWD"; then
+  echo "   already patched — skipped"
+else
+  echo "FATAL: cute-FA arch gate not found in $FA_FWD (wheel changed?) — B300 FLASH_ATTN would stay blocked" >&2
+  exit 4
+fi
+
 echo "== 4. VERIFY consistency (fail-closed: any mismatch aborts) =="
 cd /tmp && "$REPO/.venv/bin/python" - <<'PY'
 import torch, torchvision, vllm, vllm._C, vllm._C_stable_libtorch

--- a/benchmarks/poc/vector_separation.py
+++ b/benchmarks/poc/vector_separation.py
@@ -28,19 +28,26 @@ import sys
 import numpy as np
 
 
+try:  # single source of truth for the wire codec when vllm is importable
+    from vllm.poc.data import decode_vector as _decode_vector
+except ImportError:
+    def _decode_vector(s):
+        return np.frombuffer(base64.b64decode(s), dtype="<f2").astype(np.float32)
+
+
 def _slices(artifact):
     sv = artifact.get("sph_values_steps") or []
     if not sv:
         return None
-    return np.stack([
-        np.frombuffer(base64.b64decode(s), dtype="<f2").astype(np.float32)
-        for s in sv])
+    return np.stack([np.asarray(_decode_vector(s), dtype=np.float32) for s in sv])
 
 
 def pair_dists(gen_file, val_file):
     """Per-nonce mean cosine distance over decode steps (index 1..)."""
-    gen = json.load(open(gen_file))
-    val = json.load(open(val_file))
+    with open(gen_file) as f:
+        gen = json.load(f)
+    with open(val_file) as f:
+        val = json.load(f)
     g = {a["nonce"]: a for a in gen.get("artifacts", [])}
     v = {a["nonce"]: a for a in val.get("artifacts", [])}
     out = []
@@ -51,7 +58,14 @@ def pair_dists(gen_file, val_file):
         n = min(len(qp), len(qv))
         if n < 2:
             continue
-        cos = np.sum(qp[1:n] * qv[1:n], axis=1)
+        # scorer parity (score_vector_channel): common leading dims, then
+        # renormalize — wire slices are raw, not unit vectors
+        d = min(qp.shape[1], qv.shape[1])
+        a, b = qp[1:n, :d], qv[1:n, :d]
+        na = np.linalg.norm(a, axis=1)
+        nb = np.linalg.norm(b, axis=1)
+        good = (na > 0) & (nb > 0)
+        cos = np.where(good, np.sum(a * b, axis=1) / np.where(good, na * nb, 1.0), np.nan)
         ok = np.isfinite(cos)
         if ok.any():
             out.append(float(np.mean(1.0 - cos[ok])))

--- a/benchmarks/poc/vector_separation.py
+++ b/benchmarks/poc/vector_separation.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""vector_separation.py — OFFLINE vector-channel separation over collected runs.
+
+Takes GEN:VAL file pairs produced by collect.py **--debug** (the gen file carries
+the prover's per-step pre-snap sphere slices, the val file the validator's own
+teacher-forced recompute) and scores the continuous channel next to the discrete
+one, on the SAME trajectories:
+
+  per step   d_t = 1 - <q_prover, q_validator>      (decode steps 1..N)
+  per nonce  D_i = mean_t d_t
+  per pair   mean/sd/min/max of D_i  +  the discrete k-mismatch rate for contrast
+
+Honest/fraud grouping comes from the val file's results.honest flag (same rule as
+analyze.py: validator_model == prover_model). Across groups it reports AUC, d',
+the worst-honest vs weakest-fraud gap, and K — the number of nonces at which a
+mean-of-K test separates at FPR 1e-4 / power 95% (gaussian approximation).
+
+  vector_separation.py gen_honest.json:val_honest.json gen_fraud.json:val_fraud.json ...
+
+No server, no GPU — pure file analysis (numpy).
+"""
+import argparse
+import base64
+import json
+import math
+import sys
+
+import numpy as np
+
+
+def _slices(artifact):
+    sv = artifact.get("sph_values_steps") or []
+    if not sv:
+        return None
+    return np.stack([
+        np.frombuffer(base64.b64decode(s), dtype="<f2").astype(np.float32)
+        for s in sv])
+
+
+def pair_dists(gen_file, val_file):
+    """Per-nonce mean cosine distance over decode steps (index 1..)."""
+    gen = json.load(open(gen_file))
+    val = json.load(open(val_file))
+    g = {a["nonce"]: a for a in gen.get("artifacts", [])}
+    v = {a["nonce"]: a for a in val.get("artifacts", [])}
+    out = []
+    for nonce in sorted(set(g) & set(v)):
+        qp, qv = _slices(g[nonce]), _slices(v[nonce])
+        if qp is None or qv is None:
+            continue
+        n = min(len(qp), len(qv))
+        if n < 2:
+            continue
+        cos = np.sum(qp[1:n] * qv[1:n], axis=1)
+        ok = np.isfinite(cos)
+        if ok.any():
+            out.append(float(np.mean(1.0 - cos[ok])))
+    honest = bool(val.get("results", {}).get("honest", True))
+    rate = val.get("results", {}).get("rate")
+    return np.array(out), honest, rate
+
+
+def auc(honest, fraud):
+    wins = sum((1.0 if f > h else 0.5 if f == h else 0.0)
+               for h in honest for f in fraud)
+    return wins / (len(honest) * len(fraud))
+
+
+def k_to_separate(honest, fraud, z=3.719 + 1.645):
+    """Nonces needed so a mean-of-K test separates at FPR 1e-4 / power 95%.
+    z = Phi^-1(1 - 1e-4) + Phi^-1(0.95) = 3.719 + 1.645 (one-sided)."""
+    mh, sh = honest.mean(), honest.std(ddof=1)
+    mf, sf = fraud.mean(), fraud.std(ddof=1)
+    if mf <= mh:
+        return math.inf
+    return max(1, math.ceil(((z * math.sqrt((sh**2 + sf**2) / 2)) / (mf - mh))**2))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("pairs", nargs="+", metavar="GEN:VAL",
+                    help="gen/val file pair, colon-separated (both from collect.py --debug)")
+    a = ap.parse_args()
+
+    rows, hon_all, fr_all = [], [], []
+    for spec in a.pairs:
+        try:
+            gen_file, val_file = spec.split(":", 1)
+        except ValueError:
+            sys.exit(f"bad pair (want GEN:VAL): {spec}")
+        d, honest, rate = pair_dists(gen_file, val_file)
+        if not len(d):
+            print(f"SKIP {spec}: no sph_values_steps on both sides "
+                  f"(generate AND validate need --debug)")
+            continue
+        rows.append((gen_file, honest, rate, d))
+        (hon_all if honest else fr_all).append(d)
+
+    print(f"{'pair (gen)':44s} {'class':7s} {'k-rate':>8s} "
+          f"{'vec mean':>10s} {'sd':>9s} {'min..max':>21s}")
+    for gen_file, honest, rate, d in rows:
+        print(f"{gen_file[-44:]:44s} {'honest' if honest else 'FRAUD':7s} "
+              f"{(f'{rate*100:.2f}%' if rate is not None else '—'):>8s} "
+              f"{d.mean():>10.2e} {d.std(ddof=1):>9.1e} "
+              f"{d.min():>10.2e}..{d.max():<9.2e}")
+
+    if hon_all and fr_all:
+        h, f = np.concatenate(hon_all), np.concatenate(fr_all)
+        gap = f.min() / h.max() if h.max() > 0 else math.inf
+        print(f"\nhonest n={len(h)}  fraud n={len(f)}")
+        print(f"AUC={auc(h, f):.4f}   worst-honest={h.max():.2e}  "
+              f"weakest-fraud={f.min():.2e}  gap={gap:.1f}x"
+              f"{'  (NO overlap)' if gap > 1 else '  (OVERLAP)'}")
+        print(f"K (nonces to separate @ FPR 1e-4 / power .95) = {k_to_separate(h, f)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/poc/unit/test_per_nonce_reflection.py
+++ b/tests/poc/unit/test_per_nonce_reflection.py
@@ -1,0 +1,109 @@
+"""Unit tests for per-nonce Householder reflection seeding (PoCNativeState).
+
+Per-block (default): every nonce of a block reflects with ONE draw seeded by
+block_hash — the whole block shares a single measurement instrument. Per-nonce
+(opt-in, PoCParams.per_nonce_reflection): each row's vectors are seeded by
+(block_hash, nonce), so every nonce measures with its own independent draw and
+block statistics average over n independent instruments.
+
+Non-circular like the B1 stress test: buffers are compared to independently
+generated Householder vectors from the documented seed strings, never to
+self-produced values. Pure CPU.
+"""
+import torch
+
+from vllm.poc.gpu_random import generate_householder_vector
+from vllm.poc.native import PoCNativeState
+from vllm.poc.poc_params import PoCParams
+
+DEV = torch.device("cpu")
+NL, HS, MT = 4, 16, 8
+BH = "deadbeef" * 8
+
+
+def _truth(bh, layer, nonce=None):
+    """Ground-truth vectors from the documented seed-string contract."""
+    suffix = "" if nonce is None else f"_nonce{nonce}"
+    return generate_householder_vector(
+        f"{bh}{suffix}_layer_{layer}_householder", HS, DEV).to(torch.float32)
+
+
+def _assert_buffers(st, rows):
+    """rows: list of (block_hash | None, refl_nonce | None) per row."""
+    for row, (bh, nz) in enumerate(rows):
+        for layer in range(NL):
+            got = st.vectors[layer][row]
+            if bh is None:
+                assert torch.equal(got, torch.zeros(HS, device=DEV)), \
+                    f"row {row} layer {layer}: None row not zero"
+            else:
+                assert torch.allclose(got, _truth(bh, layer, nz), atol=1e-6), \
+                    f"row {row} layer {layer}: wrong vectors for ({bh}, {nz})"
+
+
+def test_per_block_seed_string_unchanged():
+    """The default (per-block) scheme must keep the LEGACY seed string — no
+    suffix — or every existing chain breaks. Omitting the argument and passing
+    all-None must both hit the legacy path."""
+    st = PoCNativeState(NL, HS, MT, DEV, torch.float32)
+    st.set_row_block_hashes([BH, BH])
+    _assert_buffers(st, [(BH, None), (BH, None)])
+    st2 = PoCNativeState(NL, HS, MT, DEV, torch.float32)
+    st2.set_row_block_hashes([BH, BH], [None, None])
+    for layer in range(NL):
+        assert torch.equal(st.vectors[layer], st2.vectors[layer])
+
+
+def test_per_nonce_rows_get_independent_draws():
+    """Same block_hash, different nonces -> DIFFERENT reflection vectors per row
+    (each nonce its own instrument); same nonce -> identical; all unit-norm."""
+    st = PoCNativeState(NL, HS, MT, DEV, torch.float32)
+    st.set_row_block_hashes([BH, BH, BH], [7, 8, 7])
+    _assert_buffers(st, [(BH, 7), (BH, 8), (BH, 7)])
+    for layer in range(NL):
+        v7, v8 = st.vectors[layer][0], st.vectors[layer][1]
+        assert not torch.allclose(v7, v8), "nonces 7/8 share a draw"
+        assert torch.equal(v7, st.vectors[layer][2]), "same nonce differs"
+        assert torch.allclose(v7.norm(), torch.tensor(1.0), atol=1e-5)
+    # per-nonce differs from the per-block draw of the same block_hash
+    assert not torch.allclose(st.vectors[0][0], _truth(BH, 0, None))
+
+
+def test_mixed_batch_per_block_and_per_nonce():
+    """Rows of a per-block request and a per-nonce request coexist in one
+    forward, each seeded by its own scheme (None rows stay zero/masked)."""
+    st = PoCNativeState(NL, HS, MT, DEV, torch.float32)
+    rows = [(BH, None), (BH, 3), (None, None), ("0xbbb", 3)]
+    st.set_row_block_hashes([r[0] for r in rows], [r[1] for r in rows])
+    _assert_buffers(st, rows)
+
+
+def test_skip_key_covers_nonces():
+    """Changing ONLY the reflection nonces (same row_hashes) must rescatter —
+    the B1 skip key has to include the nonce mapping."""
+    st = PoCNativeState(NL, HS, MT, DEV, torch.float32)
+    st.set_row_block_hashes([BH, BH], [1, 2])
+    _assert_buffers(st, [(BH, 1), (BH, 2)])
+    st.set_row_block_hashes([BH, BH], [2, 1])       # same hashes, swapped nonces
+    _assert_buffers(st, [(BH, 2), (BH, 1)])
+    st.set_row_block_hashes([BH, BH])               # back to per-block
+    _assert_buffers(st, [(BH, None), (BH, None)])
+
+
+def test_cache_bound_keeps_buffers_correct():
+    """Blowing past the cache cap must only cost regeneration, never correctness."""
+    st = PoCNativeState(NL, HS, MT, DEV, torch.float32)
+    st._HASH_CACHE_MAX = 4
+    for start in range(0, 24, 2):
+        nzs = [start, start + 1]
+        st.set_row_block_hashes([BH, BH], nzs)
+        _assert_buffers(st, [(BH, nzs[0]), (BH, nzs[1])])
+    assert len(st._hash_cache) <= 4
+
+
+def test_poc_params_carries_and_clones_flag():
+    p = PoCParams(block_hash=BH, public_key="pk", block_height=1, nonce=5)
+    assert p.per_nonce_reflection is False          # default: legacy behavior
+    p2 = PoCParams(block_hash=BH, public_key="pk", block_height=1, nonce=5,
+                   per_nonce_reflection=True)
+    assert p2.clone().per_nonce_reflection is True

--- a/tests/poc/unit/test_vector_artifacts.py
+++ b/tests/poc/unit/test_vector_artifacts.py
@@ -1,0 +1,149 @@
+"""Windowed/sliced vector artifacts (poc_vector_artifacts).
+
+Wire slices are raw (NOT renormalized); the scorer truncates both sides to
+the common leading dims and renormalizes, so full-debug and windowed
+artifacts interoperate. Pure CPU math.
+"""
+import numpy as np
+
+from vllm.poc.data import decode_vector, encode_vector
+from vllm.poc.mixed_decode import (_vector_artifact_cfg, encode_sph_slices,
+                                   keep_q_step)
+from vllm.poc.validation import score_vector_channel
+
+
+def _unit(v):
+    v = np.asarray(v, dtype=np.float32)
+    return v / np.linalg.norm(v)
+
+
+def _traj(vecs, dim=None):
+    """Encode prefill + decode-step slices, optionally wire-truncated to dim."""
+    rows = [_unit(np.ones(256))] + [_unit(v) for v in vecs]
+    if dim is not None:
+        rows = [r[:dim] for r in rows]           # raw slice, no renorm (wire)
+    return [encode_vector(r) for r in rows]
+
+
+def test_config_defaults_off_and_sized():
+    from vllm.config import CacheConfig
+    cc = CacheConfig()
+    assert cc.poc_vector_artifacts is False
+    assert cc.poc_vector_artifact_steps == 64
+    assert cc.poc_vector_artifact_dim == 32
+
+
+def test_cfg_helper_disabled_without_engine_config():
+    class Bare:
+        pass
+    # only element [0] is load-bearing: with enabled=False every consumer
+    # gates on it first, steps/dim are dead
+    assert _vector_artifact_cfg(Bare())[0] is False
+
+
+def test_cfg_helper_reads_cache_config():
+    class CC:
+        poc_vector_artifacts = True
+        poc_vector_artifact_steps = 16
+        poc_vector_artifact_dim = 8
+
+    class VC:
+        cache_config = CC()
+
+    class Runner:
+        vllm_config = VC()
+
+    assert _vector_artifact_cfg(Runner()) == (True, 16, 8)
+
+
+def test_windowed_slices_score_like_full_vectors():
+    """Same trajectories shipped full-256D vs wire-sliced to 32 dims must give
+    the same distance up to the slice's own geometry (identical vectors -> 0)."""
+    rng = np.random.default_rng(3)
+    steps = [rng.standard_normal(256) for _ in range(4)]
+    full = [{"nonce": 0, "sph_values_steps": _traj(steps)}]
+    sliced = [{"nonce": 0, "sph_values_steps": _traj(steps, dim=32)}]
+    s_full = score_vector_channel(full, {0: _traj(steps)})
+    s_sliced = score_vector_channel(sliced, {0: _traj(steps, dim=32)})
+    assert s_full["mean_dist"] < 1e-5
+    assert s_sliced["mean_dist"] < 1e-5
+    assert s_sliced["per_nonce"][0]["n_steps_scored"] == 4
+
+
+def test_mixed_dims_truncate_to_common_leading_slice():
+    """A full-256D side scored against a 32-dim windowed side must equal the
+    both-sides-32 score (min-dim truncation + renorm)."""
+    rng = np.random.default_rng(5)
+    ref_steps = [rng.standard_normal(256) for _ in range(3)]
+    own_steps = [v + 0.05 * rng.standard_normal(256) for v in ref_steps]
+    both32 = score_vector_channel(
+        [{"nonce": 0, "sph_values_steps": _traj(own_steps, dim=32)}],
+        {0: _traj(ref_steps, dim=32)})
+    mixed = score_vector_channel(
+        [{"nonce": 0, "sph_values_steps": _traj(own_steps)}],
+        {0: _traj(ref_steps, dim=32)})
+    assert abs(both32["mean_dist"] - mixed["mean_dist"]) < 1e-4
+
+
+def test_scorer_renormalizes_raw_slices():
+    """Wire slices are not unit vectors; cosine must be computed on the
+    renormalized slices, not the raw dot product."""
+    v = np.zeros(256, dtype=np.float32)
+    v[0], v[32] = 0.6, 0.8                       # unit in 256-D, |slice|=0.6
+    ref = [{"nonce": 0, "sph_values_steps": _traj([v], dim=32)}]
+    s = score_vector_channel(ref, {0: _traj([v], dim=32)})
+    # identical slices: renormalized cosine distance is 0 (raw dot were 0.36)
+    assert s["mean_dist"] < 1e-6
+
+
+def test_window_shorter_than_full_traj_scores_available_steps():
+    """Validator with a full trajectory vs a prover artifact windowed to 2
+    decode steps: only the common window is scored."""
+    rng = np.random.default_rng(9)
+    steps = [rng.standard_normal(256) for _ in range(6)]
+    own_full = [{"nonce": 0, "sph_values_steps": _traj(steps)}]
+    ref_window = {0: _traj(steps[:2], dim=32)}
+    s = score_vector_channel(own_full, ref_window)
+    assert s["per_nonce"][0]["n_steps_scored"] == 2
+    assert s["mean_dist"] < 1e-5
+
+
+def test_window_keeps_prefill_plus_exactly_va_steps():
+    kept = sum(keep_q_step(s, False, True, 64) for s in range(1, 257))
+    assert kept == 64                       # + the prefill point kept at setup
+    assert all(keep_q_step(s, True, False, 0) for s in range(1, 257))  # debug
+    assert not keep_q_step(1, False, False, 64)                        # both off
+
+
+def test_window_longer_than_chain_degrades_to_full_trajectory():
+    assert sum(keep_q_step(s, False, True, 1000) for s in range(1, 257)) == 256
+
+
+def test_emitter_ships_raw_unrenormalized_slices():
+    v = np.zeros((1, 256), dtype=np.float32)
+    v[0, 0], v[0, 32] = 0.6, 0.8            # unit in 256-D, |leading 32| = 0.6
+    wire = encode_sph_slices(v, debug=False, va_on=True, va_dim=32)
+    row = decode_vector(wire[0])
+    assert row.shape == (32,)
+    assert abs(float(np.linalg.norm(row)) - 0.6) < 1e-3   # raw, NOT renormalized
+
+
+def test_emitter_dim_beyond_sphere_degrades_to_full_width():
+    v = np.random.default_rng(1).standard_normal((2, 256)).astype(np.float32)
+    wire = encode_sph_slices(v, debug=False, va_on=True, va_dim=512)
+    assert decode_vector(wire[0]).shape == (256,)
+    full = encode_sph_slices(v, debug=True, va_on=False, va_dim=32)
+    assert decode_vector(full[0]).shape == (256,)          # debug: full width
+
+
+def test_zero_norm_slice_is_a_fault_not_a_distance():
+    good = _unit(np.ones(32))
+    zero = np.zeros(32, dtype=np.float32)
+    traj = [encode_vector(_unit(np.ones(32))), encode_vector(zero),
+            encode_vector(good)]
+    s = score_vector_channel([{"nonce": 0, "sph_values_steps": traj}], {0: traj})
+    e = s["per_nonce"][0]
+    assert e["n_bad_steps"] == 1
+    assert e["n_steps_scored"] == 1
+    assert e["mean_dist"] < 1e-6
+    assert s["n_bad_steps_total"] == 1

--- a/tests/poc/unit/test_vector_channel.py
+++ b/tests/poc/unit/test_vector_channel.py
@@ -1,0 +1,93 @@
+"""Unit tests for the continuous vector-channel score (vllm/poc/validation.py
+score_vector_channel + its run_validation plumbing).
+
+The channel compares the prover's per-step pre-snap sphere slices
+(sph_values_steps, fp16-LE base64 — same wire codec as vector_b64) against the
+validator's own teacher-forced recompute: d_t = 1 - <q_p, q_v> over decode
+steps (index 0 = prefill is excluded), mean per nonce. It is EVIDENCE next to
+the k-based verdict, never a verdict change. Pure CPU math.
+"""
+import numpy as np
+
+from vllm.poc.data import decode_vector, encode_vector
+from vllm.poc.validation import run_validation, score_vector_channel
+
+
+def _unit(v):
+    v = np.asarray(v, dtype=np.float32)
+    return v / np.linalg.norm(v)
+
+
+def _steps(*vecs):
+    """Encode a trajectory: prefill slice + the given decode-step slices."""
+    prefill = _unit(np.ones(4))
+    return [encode_vector(prefill)] + [encode_vector(_unit(v)) for v in vecs]
+
+
+def test_wire_codec_roundtrip_keeps_unit_norm():
+    rng = np.random.default_rng(7)
+    q = _unit(rng.standard_normal(256))
+    back = decode_vector(encode_vector(q))
+    assert back.shape == (256,)
+    # fp16 quantization noise only — far below any honest floor of interest
+    assert abs(float(np.linalg.norm(back)) - 1.0) < 1e-3
+    assert 1.0 - float(np.dot(_unit(back), q)) < 1e-6
+
+
+def test_identical_slices_score_zero_and_orthogonal_score_one():
+    e0, e1 = [1, 0, 0, 0], [0, 1, 0, 0]
+    computed = [{"nonce": 0, "sph_values_steps": _steps(e0, e0)},
+                {"nonce": 1, "sph_values_steps": _steps(e0, e0)}]
+    # nonce 0: reference identical -> 0; nonce 1: both steps orthogonal -> 1
+    ref = {0: _steps(e0, e0), 1: _steps(e1, e1)}
+    score = score_vector_channel(computed, ref)
+    by = {e["nonce"]: e for e in score["per_nonce"]}
+    assert by[0]["mean_dist"] < 1e-6
+    assert abs(by[1]["mean_dist"] - 1.0) < 1e-3
+    assert score["n_nonces_scored"] == 2
+    assert abs(score["max_nonce_dist"] - by[1]["mean_dist"]) < 1e-9
+
+
+def test_prefill_slice_is_excluded_from_the_score():
+    e0, e1 = [1, 0, 0, 0], [0, 1, 0, 0]
+    # trajectories whose PREFILL slices disagree maximally but decode steps agree
+    computed = [{"nonce": 0,
+                 "sph_values_steps": [encode_vector(_unit(e0)),
+                                      encode_vector(_unit(e0))]}]
+    ref = {0: [encode_vector(_unit(e1)), encode_vector(_unit(e0))]}
+    score = score_vector_channel(computed, ref)
+    assert score["per_nonce"][0]["mean_dist"] < 1e-6   # prefill mismatch ignored
+
+
+def test_non_finite_slice_is_a_fault_not_a_distance():
+    e0 = [1, 0, 0, 0]
+    bad = [float("nan"), 0, 0, 0]
+    computed = [{"nonce": 0, "sph_values_steps": _steps(e0, bad)}]
+    ref = {0: _steps(e0, e0)}
+    score = score_vector_channel(computed, ref)
+    e = score["per_nonce"][0]
+    assert e["n_steps_scored"] == 1 and e["n_bad_steps"] == 1
+    assert e["mean_dist"] < 1e-6                       # only the finite step counts
+
+
+def test_score_is_none_without_vectors_on_both_sides():
+    assert score_vector_channel([{"nonce": 0}], {0: _steps([1, 0, 0, 0])}) is None
+    assert score_vector_channel(
+        [{"nonce": 0, "sph_values_steps": _steps([1, 0, 0, 0])}], {}) is None
+
+
+def test_run_validation_attaches_vector_score_but_verdict_stays_k_based():
+    e0, e1 = [1, 0, 0, 0], [0, 1, 0, 0]
+    arts = [{"nonce": 0, "k_points_steps": [1, 2, 3], "n_sphere_mismatches": 0,
+             "sph_values_steps": _steps(e0, e0)}]
+    ref = {0: _steps(e1, e1)}   # vector channel screams (dist ~1)...
+    res = run_validation(arts, {}, n_total=1, use_trajectory=True,
+                         ref_vectors=ref)
+    assert "vector_score" in res
+    assert abs(res["vector_score"]["mean_dist"] - 1.0) < 1e-3
+    assert res["fraud_detected"] is False   # ...but the k-verdict is unchanged
+    # and without ref vectors the response shape is exactly the old one
+    res2 = run_validation(arts, {}, n_total=1, use_trajectory=True)
+    assert "vector_score" not in res2
+    assert {k for k in res2} == {"n_total", "n_mismatch", "mismatch_nonces",
+                                 "per_nonce", "p_value", "fraud_detected"}

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -187,6 +187,24 @@ class CacheConfig:
     """Maximum number of decode steps per PoC nonce. Set to 0 when PoC runs
     prefill-only."""
 
+    poc_vector_artifacts: bool = Field(default=False)
+    """Emit windowed pre-snap sphere vectors (``sph_values_steps``) in PoC
+    artifacts without ``debug``: the prefill point + the first
+    ``poc_vector_artifact_steps`` decode steps, truncated to
+    ``poc_vector_artifact_dim`` leading coordinates. Emission only — the
+    forward, the k-id chain and the verdict are unchanged."""
+
+    poc_vector_artifact_steps: int = Field(default=64, gt=0)
+    """Leading decode steps emitted when ``poc_vector_artifacts`` is on. The
+    early window separates best: honest cross-HW drift compounds along the
+    chain while a weight-substitution signal is full-size from step 1."""
+
+    poc_vector_artifact_dim: int = Field(default=32, gt=0, le=256)
+    """Leading coordinates kept per emitted vector (raw slice of the
+    SPHERE_DIM unit vector; the scorer renormalizes both sides). The 32-D
+    default empirically matches full 256-D detection power. Upper bound =
+    SPHERE_DIM, kept literal to avoid a config->poc import."""
+
     poc_share: float = Field(default=0.5, ge=0.0, le=1.0)
     """Fraction of each scheduler step's token budget PoC may consume; chat gets
     the rest. Explicit knob over the chat<->PoC mix: 1.0 = PoC greedy, 0.0 = chat
@@ -222,6 +240,10 @@ class CacheConfig:
             "poc_seq_len",
             "poc_max_tokens",
             "poc_share",
+            # PoC artifact-emission knobs — post-forward host-side emission only
+            "poc_vector_artifacts",
+            "poc_vector_artifact_steps",
+            "poc_vector_artifact_dim",
             # Post-init/derived counters
             "num_gpu_blocks",
             "num_cpu_blocks",

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -673,6 +673,9 @@ class EngineArgs:
     poc_seq_len: int = get_field(CacheConfig, "poc_seq_len")
     poc_max_tokens: int = get_field(CacheConfig, "poc_max_tokens")
     poc_share: float = get_field(CacheConfig, "poc_share")
+    poc_vector_artifacts: bool = get_field(CacheConfig, "poc_vector_artifacts")
+    poc_vector_artifact_steps: int = get_field(CacheConfig, "poc_vector_artifact_steps")
+    poc_vector_artifact_dim: int = get_field(CacheConfig, "poc_vector_artifact_dim")
 
     shutdown_timeout: int = 0
 
@@ -1119,6 +1122,17 @@ class EngineArgs:
         )
         cache_group.add_argument(
             "--poc-max-tokens", **cache_kwargs["poc_max_tokens"]
+        )
+        cache_group.add_argument(
+            "--poc-vector-artifacts", **cache_kwargs["poc_vector_artifacts"]
+        )
+        cache_group.add_argument(
+            "--poc-vector-artifact-steps",
+            **cache_kwargs["poc_vector_artifact_steps"]
+        )
+        cache_group.add_argument(
+            "--poc-vector-artifact-dim",
+            **cache_kwargs["poc_vector_artifact_dim"]
         )
         cache_group.add_argument(
             "--poc-share", **cache_kwargs["poc_share"]
@@ -1688,6 +1702,9 @@ class EngineArgs:
             poc_seq_len=self.poc_seq_len,
             poc_max_tokens=self.poc_max_tokens,
             poc_share=self.poc_share,
+            poc_vector_artifacts=self.poc_vector_artifacts,
+            poc_vector_artifact_steps=self.poc_vector_artifact_steps,
+            poc_vector_artifact_dim=self.poc_vector_artifact_dim,
         )
 
         # TurboQuant: auto-skip first/last 2 layers (boundary protection).

--- a/vllm/poc/callbacks.py
+++ b/vllm/poc/callbacks.py
@@ -12,6 +12,15 @@ from .data import Artifact
 
 logger = init_logger(__name__)
 
+
+def _artifact_payload(a) -> dict:
+    d = {"nonce": a.nonce, "vector_b64": a.vector_b64}
+    if a.k_points_steps is not None:
+        d["k_points_steps"] = a.k_points_steps
+    if getattr(a, "sph_values_steps", None):
+        d["sph_values_steps"] = a.sph_values_steps
+    return d
+
 POC_CALLBACK_INTERVAL_SEC = float(os.environ.get("POC_CALLBACK_INTERVAL_SEC", "5"))
 POC_CALLBACK_MAX_ARTIFACTS = int(os.environ.get("POC_CALLBACK_MAX_ARTIFACTS", "1000000"))
 POC_CALLBACK_RETRY_BACKOFF_SEC = 1.0
@@ -83,15 +92,11 @@ class CallbackSender:
                     self._buffer.clear()
                     self._pending_payload = {
                         **self._metadata,
-                        # decode PoC: include the sphere_k trajectory; prefill leaves
-                        # it out (key absent) so the payload is byte-unchanged there.
-                        "artifacts": [
-                            ({"nonce": a.nonce, "vector_b64": a.vector_b64}
-                             if a.k_points_steps is None else
-                             {"nonce": a.nonce, "vector_b64": a.vector_b64,
-                              "k_points_steps": a.k_points_steps})
-                            for a in artifacts_to_send
-                        ],
+                        # decode PoC adds the sphere_k trajectory; the vector
+                        # window (poc_vector_artifacts/debug) adds sph_values_steps.
+                        # Absent fields leave no key, so prefill payloads stay
+                        # byte-unchanged.
+                        "artifacts": [_artifact_payload(a) for a in artifacts_to_send],
                         "encoding": {"dtype": "f16", "k_dim": self.k_dim, "endian": "le"},
                     }
                     retry_attempt = 0

--- a/vllm/poc/data.py
+++ b/vllm/poc/data.py
@@ -20,6 +20,8 @@ class Artifact:
     nonce: int
     vector_b64: str
     k_points_steps: Optional[List[int]] = None
+    # windowed pre-snap slices (poc_vector_artifacts) or full debug trajectory
+    sph_values_steps: Optional[List[str]] = None
 
 
 @dataclass

--- a/vllm/poc/generate_queue.py
+++ b/vllm/poc/generate_queue.py
@@ -72,7 +72,8 @@ async def compute_nonce_artifacts(
                     return None
                 get = poc_out.get if isinstance(poc_out, dict) else (
                     lambda k, d=None: getattr(poc_out, k, d))
-                # sph_* debug fields are only included when debug is on.
+                # sph_indices_steps is debug-only; sph_values_steps is emitted
+                # under debug (full) or poc_vector_artifacts (windowed slice).
                 artifact = {
                     "nonce": get("nonce", nonce),
                     "vector_b64": get("vector_b64", ""),
@@ -83,6 +84,10 @@ async def compute_nonce_artifacts(
                 if debug:
                     artifact["sph_indices_steps"] = get("sph_indices_steps", [])
                     artifact["sph_values_steps"] = get("sph_values_steps", [])
+                else:
+                    sph_vals = get("sph_values_steps", [])
+                    if sph_vals:
+                        artifact["sph_values_steps"] = sph_vals
                 return artifact
         except Exception as e:
             logger.error("Error computing nonce %s: %r", nonce, e, exc_info=True)
@@ -119,8 +124,9 @@ class GenerateJob:
     debug: bool = False
     per_nonce_reflection: bool = False
     validation_artifacts: Optional[Dict[int, str]] = None
-    # nonce -> reference sph_values_steps (debug refs): enables the continuous
-    # vector_score on the queued path, same as the inline wait=true path.
+    # nonce -> reference sph_values_steps (debug or poc_vector_artifacts refs):
+    # enables the continuous vector_score on the queued path, same as the
+    # inline wait=true path.
     ref_vectors: Optional[Dict[int, List[str]]] = None
     stat_test_dist_threshold: float = DEFAULT_DIST_THRESHOLD
     stat_test_p_mismatch: float = DEFAULT_P_MISMATCH

--- a/vllm/poc/generate_queue.py
+++ b/vllm/poc/generate_queue.py
@@ -27,6 +27,7 @@ async def compute_nonce_artifacts(
     max_tokens: int = 0,
     enforced_k_steps: Optional[Dict[int, List[int]]] = None,
     debug: bool = False,
+    per_nonce_reflection: bool = False,
 ) -> List[dict]:
     """Compute PoC artifacts for a set of nonces via the scheduler.
 
@@ -53,6 +54,7 @@ async def compute_nonce_artifacts(
             max_tokens=max_tokens,
             enforced_k_steps=inf_steps,
             debug=debug,
+            per_nonce_reflection=per_nonce_reflection,
         )
         request_id = f"poc-{uuid.uuid4()}"
         # PoC emits its artifact ONCE (emit-once): a single finished output
@@ -115,6 +117,7 @@ class GenerateJob:
     max_tokens: int = 0
     enforced_k_steps: Optional[Dict[int, List[int]]] = None
     debug: bool = False
+    per_nonce_reflection: bool = False
     validation_artifacts: Optional[Dict[int, str]] = None
     # nonce -> reference sph_values_steps (debug refs): enables the continuous
     # vector_score on the queued path, same as the inline wait=true path.
@@ -322,6 +325,7 @@ class GenerateQueue:
                     max_tokens=job.max_tokens,
                     enforced_k_steps=chunk_inference_steps,
                     debug=job.debug,
+                    per_nonce_reflection=job.per_nonce_reflection,
                 )
             except asyncio.CancelledError:
                 logger.info(f"PoC queue job {job.request_id[:8]}: cancelled")

--- a/vllm/poc/generate_queue.py
+++ b/vllm/poc/generate_queue.py
@@ -116,6 +116,9 @@ class GenerateJob:
     enforced_k_steps: Optional[Dict[int, List[int]]] = None
     debug: bool = False
     validation_artifacts: Optional[Dict[int, str]] = None
+    # nonce -> reference sph_values_steps (debug refs): enables the continuous
+    # vector_score on the queued path, same as the inline wait=true path.
+    ref_vectors: Optional[Dict[int, List[str]]] = None
     stat_test_dist_threshold: float = DEFAULT_DIST_THRESHOLD
     stat_test_p_mismatch: float = DEFAULT_P_MISMATCH
     stat_test_fraud_threshold: float = DEFAULT_FRAUD_THRESHOLD
@@ -348,12 +351,16 @@ class GenerateQueue:
             fraud_threshold=job.stat_test_fraud_threshold,
             k_dim=job.k_dim,
             use_trajectory=job.max_tokens > 0,
+            ref_vectors=job.ref_vectors,
         )
         
         return {
             "status": "completed",
             "request_id": job.request_id,
             **validation_result,
+            # parity with the inline wait=true path (routes.py): debug requests
+            # get the validator-side artifacts (sph_values_steps) back too.
+            "artifacts": computed_artifacts if job.debug else [],
         }
     
     def _enqueue_callback(self, job: GenerateJob, result: Dict[str, Any]):
@@ -385,6 +392,9 @@ class GenerateQueue:
                 "mismatch_nonces": result.get("mismatch_nonces", []),
                 "p_value": result.get("p_value", 1.0),
                 "fraud_detected": result.get("fraud_detected", False),
+                # continuous vector-channel evidence (present when the reference
+                # artifacts carried sph_values_steps); None otherwise.
+                "vector_score": result.get("vector_score"),
             }
             self._callback_queue.enqueue(job.callback_url, "validated", payload)
 

--- a/vllm/poc/mixed_decode.py
+++ b/vllm/poc/mixed_decode.py
@@ -40,6 +40,34 @@ _MARGIN_TAU = float(os.environ.get("VLLM_POC_MARGIN_TAU", "0") or "0")
 POC_DEFER_LIMIT = 4
 
 
+def _vector_artifact_cfg(runner) -> tuple:
+    """(enabled, steps, dim) emission knobs from the engine's CacheConfig.
+    The fallbacks are load-bearing: these files get overlaid onto vLLM trees
+    whose config may predate the fields — then disable, don't raise."""
+    cc = getattr(getattr(runner, "vllm_config", None), "cache_config", None)
+    if cc is None:
+        return False, 64, 32
+    return (bool(getattr(cc, "poc_vector_artifacts", False)),
+            int(getattr(cc, "poc_vector_artifact_steps", 64)),
+            int(getattr(cc, "poc_vector_artifact_dim", 32)))
+
+
+def keep_q_step(step: int, debug: bool, va_on: bool, va_steps: int) -> bool:
+    """Which decode steps retain their pre-snap slice for emission: all under
+    debug, the leading va_steps window under poc_vector_artifacts. Pure."""
+    return debug or (va_on and step <= va_steps)
+
+
+def encode_sph_slices(q_host, debug: bool, va_on: bool, va_dim: int) -> list:
+    """Wire-encode kept slices (one fp16-LE base64 row, vector_b64 codec).
+    Flag mode ships the raw leading va_dim coords — NOT renormalized; the
+    scorer renormalizes both sides. Debug ships full width. Pure."""
+    from .data import encode_vector
+    if not debug and va_on:
+        q_host = q_host[:, :va_dim]
+    return [encode_vector(row) for row in q_host]
+
+
 def slice_sampling_metadata(sm, rows, device):
     """Restrict a SamplingMetadata to `rows` (input_batch indices), so the sampler
     runs on chat rows only. PoC rows have no sampling semantics; keeping them out
@@ -175,11 +203,11 @@ class PoCDecodeState:
     mismatch_t: "torch.Tensor | None" = None      # [1] int64 on-device accumulator
     n_nan_t: "torch.Tensor | None" = None         # [1] int64 non-finite-step counter (device)
     k_steps_t: list = field(default_factory=list)  # list of [1] int64; cat+tolist at end
-    # debug only (PoCParams.debug): the per-step pre-snap sphere slices — the same
-    # q whose argmax is sphere_k — kept so the documented PoCOutput.sph_values_steps
-    # contract (v1/outputs.py) can be emitted. list of [1, SPHERE_DIM] float tensors,
-    # index 0 = prefill, 1..N = decode; device-accumulated like k_steps_t (no
-    # per-step host sync), encoded once at emit.
+    # per-step pre-snap sphere slices (the q whose argmax is sphere_k) for
+    # PoCOutput.sph_values_steps: full trajectory under debug, prefill +
+    # leading poc_vector_artifact_steps window under poc_vector_artifacts.
+    # [1, SPHERE_DIM] floats, index 0 = prefill; device-accumulated like
+    # k_steps_t (no per-step host sync), encoded once at emit.
     q_steps_t: list = field(default_factory=list)
 
 
@@ -442,6 +470,8 @@ def process_poc_outputs_from_hidden(
     if codebook is None:
         codebook = get_sphere_codebook().to(device=runner.device)
         runner._poc_codebook = codebook
+    # engine-static: safe to fetch once per forward
+    va_on, va_steps, va_dim = _vector_artifact_cfg(runner)
 
     # Decode steps are the hot path; collect them and run ONE batched set of GPU
     # ops for the whole nonce-batch below (was a per-nonce Python loop = B× the
@@ -499,8 +529,8 @@ def process_poc_outputs_from_hidden(
             hidden_size, SPHERE_DIM, runner.device)
         k0_t, bad0, margin0, q0 = _sphere_from_idx(sph0)    # [1]/[1]/[1]/[1,SPHERE_DIM]
         st.k_steps_t = [k0_t]
-        # debug: keep the pre-snap slice so sph_values_steps can be emitted
-        st.q_steps_t = [q0.detach()] if poc_params.debug else []
+        # emission only — forward unchanged (contract: q_steps_t field doc)
+        st.q_steps_t = [q0.detach()] if (poc_params.debug or va_on) else []
         st.mismatch_t = torch.zeros(1, dtype=torch.int64, device=runner.device)
         st.n_nan_t = bad0.to(torch.int64)                   # [1] non-finite-step counter
         if st.reference is not None:
@@ -532,16 +562,17 @@ def process_poc_outputs_from_hidden(
         # snap_with_margin: argmax(NaN) is garbage -> non-finite rows return k=-1
         # (compute fault, NOT fraud). bad_all/margin_all stay on device (no per-step sync).
         q_all = project_to_sphere(torch.gather(lh, 1, sph))          # [B, SPHERE_DIM]
-        k_all, bad_all, margin_all = snap_with_margin(q_all, codebook)  # [B] int64/bool/float
+        k_all, bad_all, margin_all = snap_with_margin(q_all, codebook)  # [B] each
 
         for i, meta in enumerate(decode_metas):
             st = meta['decode_state']
             step = meta['decode_step']
             k_t = k_all[i:i + 1]                               # [1] tensor (view)
             st.k_steps_t.append(k_t)
-            if meta['poc_params'].debug:
-                # debug: keep the pre-snap slice (device, like k_steps_t — no sync)
-                st.q_steps_t.append(q_all[i:i + 1].detach())
+            if keep_q_step(step, meta['poc_params'].debug, va_on, va_steps):
+                # device-side like k_steps_t — no per-step host sync; clone so
+                # a lone debug row does not pin the whole [B, SPHERE_DIM] batch
+                st.q_steps_t.append(q_all[i:i + 1].detach().clone())
             st.n_nan_t += bad_all[i:i + 1].to(torch.int64)    # device accumulate (no sync)
             if st.reference_t is not None and step < st.reference_t.shape[0]:
                 ref = st.reference_t[step:step + 1]
@@ -565,15 +596,13 @@ def process_poc_outputs_from_hidden(
                         "(compute fault, NOT fraud; excluded from mismatch rate) — "
                         "trajectory suspect, re-run on a clean GPU",
                         meta['poc_params'].nonce, n_nan, len(k_points))
-                # debug: emit the documented sph_values_steps contract (v1/outputs.py)
-                # — one fp16-LE base64 slice per trajectory step, same wire format as
-                # vector_b64 (data.encode_vector). Single host copy, emit-once.
                 sph_vals = []
-                if meta['poc_params'].debug and st.q_steps_t:
+                if st.q_steps_t:
                     # cat on device, then ONE host copy for the whole trajectory
                     # (a per-step .cpu() would sync T+1 times at emit).
                     q_host = torch.cat(st.q_steps_t).cpu().numpy()
-                    sph_vals = [encode_vector(row) for row in q_host]
+                    sph_vals = encode_sph_slices(
+                        q_host, meta['poc_params'].debug, va_on, va_dim)
                 poc_outputs[meta['req_id']] = PoCOutput(
                     nonce=meta['poc_params'].nonce,
                     vector_b64="",

--- a/vllm/poc/mixed_decode.py
+++ b/vllm/poc/mixed_decode.py
@@ -175,6 +175,12 @@ class PoCDecodeState:
     mismatch_t: "torch.Tensor | None" = None      # [1] int64 on-device accumulator
     n_nan_t: "torch.Tensor | None" = None         # [1] int64 non-finite-step counter (device)
     k_steps_t: list = field(default_factory=list)  # list of [1] int64; cat+tolist at end
+    # debug only (PoCParams.debug): the per-step pre-snap sphere slices — the same
+    # q whose argmax is sphere_k — kept so the documented PoCOutput.sph_values_steps
+    # contract (v1/outputs.py) can be emitted. list of [1, SPHERE_DIM] float tensors,
+    # index 0 = prefill, 1..N = decode; device-accumulated like k_steps_t (no
+    # per-step host sync), encoded once at emit.
+    q_steps_t: list = field(default_factory=list)
 
 
 class PoCMixedDecodeManager:
@@ -469,10 +475,12 @@ def process_poc_outputs_from_hidden(
             return encode_vector(yk.half().cpu().numpy())
 
         def _sphere_from_idx(sph):
-            """hidden -> (sphere index, non-finite mask, margin) as [1] TENSORs
-            (no .item(), so the chain stays on GPU and async scheduling works)."""
+            """hidden -> (sphere index, non-finite mask, margin, pre-snap slice) as
+            [1]/[1]/[1]/[1, SPHERE_DIM] TENSORs (no .item(), so the chain stays on
+            GPU and async scheduling works)."""
             xk_sphere = project_to_sphere(torch.gather(last_hidden.unsqueeze(0), 1, sph))
-            return snap_with_margin(xk_sphere, codebook)  # (k[1], bad[1], margin[1])
+            k_, bad_, margin_ = snap_with_margin(xk_sphere, codebook)
+            return k_, bad_, margin_, xk_sphere
 
         if st is None:
             # Prefill-only PoC: just the vector_b64 artifact.
@@ -489,8 +497,10 @@ def process_poc_outputs_from_hidden(
         sph0 = random_pick_indices(
             poc_params.block_hash, poc_params.public_key, [nonce],
             hidden_size, SPHERE_DIM, runner.device)
-        k0_t, bad0, margin0 = _sphere_from_idx(sph0)        # [1] tensors
+        k0_t, bad0, margin0, q0 = _sphere_from_idx(sph0)    # [1]/[1]/[1]/[1,SPHERE_DIM]
         st.k_steps_t = [k0_t]
+        # debug: keep the pre-snap slice so sph_values_steps can be emitted
+        st.q_steps_t = [q0.detach()] if poc_params.debug else []
         st.mismatch_t = torch.zeros(1, dtype=torch.int64, device=runner.device)
         st.n_nan_t = bad0.to(torch.int64)                   # [1] non-finite-step counter
         if st.reference is not None:
@@ -521,14 +531,17 @@ def process_poc_outputs_from_hidden(
         sph = random_pick_indices_gpu(base_seeds, prev_k, steps, H, SPHERE_DIM, device)
         # snap_with_margin: argmax(NaN) is garbage -> non-finite rows return k=-1
         # (compute fault, NOT fraud). bad_all/margin_all stay on device (no per-step sync).
-        k_all, bad_all, margin_all = snap_with_margin(
-            project_to_sphere(torch.gather(lh, 1, sph)), codebook)   # [B] int64/bool/float
+        q_all = project_to_sphere(torch.gather(lh, 1, sph))          # [B, SPHERE_DIM]
+        k_all, bad_all, margin_all = snap_with_margin(q_all, codebook)  # [B] int64/bool/float
 
         for i, meta in enumerate(decode_metas):
             st = meta['decode_state']
             step = meta['decode_step']
             k_t = k_all[i:i + 1]                               # [1] tensor (view)
             st.k_steps_t.append(k_t)
+            if meta['poc_params'].debug:
+                # debug: keep the pre-snap slice (device, like k_steps_t — no sync)
+                st.q_steps_t.append(q_all[i:i + 1].detach())
             st.n_nan_t += bad_all[i:i + 1].to(torch.int64)    # device accumulate (no sync)
             if st.reference_t is not None and step < st.reference_t.shape[0]:
                 ref = st.reference_t[step:step + 1]
@@ -552,6 +565,15 @@ def process_poc_outputs_from_hidden(
                         "(compute fault, NOT fraud; excluded from mismatch rate) — "
                         "trajectory suspect, re-run on a clean GPU",
                         meta['poc_params'].nonce, n_nan, len(k_points))
+                # debug: emit the documented sph_values_steps contract (v1/outputs.py)
+                # — one fp16-LE base64 slice per trajectory step, same wire format as
+                # vector_b64 (data.encode_vector). Single host copy, emit-once.
+                sph_vals = []
+                if meta['poc_params'].debug and st.q_steps_t:
+                    # cat on device, then ONE host copy for the whole trajectory
+                    # (a per-step .cpu() would sync T+1 times at emit).
+                    q_host = torch.cat(st.q_steps_t).cpu().numpy()
+                    sph_vals = [encode_vector(row) for row in q_host]
                 poc_outputs[meta['req_id']] = PoCOutput(
                     nonce=meta['poc_params'].nonce,
                     vector_b64="",
@@ -559,6 +581,7 @@ def process_poc_outputs_from_hidden(
                     n_sphere_mismatches=(
                         n_mismatches if st.reference is not None else -1),
                     n_nan_steps=n_nan,
+                    sph_values_steps=sph_vals,
                 )
                 get_decode_manager(runner).free(meta['req_id'])
 

--- a/vllm/poc/native.py
+++ b/vllm/poc/native.py
@@ -177,8 +177,11 @@ class PoCNativeState:
         ]
         self.mask = torch.zeros(max_tokens, dtype=torch.bool, device=device)
         self.embeds = torch.zeros(max_tokens, hidden_size, device=device, dtype=dtype)
-        self._hash_cache: dict[str, list] = {}      # block_hash -> per-layer vectors
-        self._last_row_hashes: list | None = None   # skip redundant per-step rescatter
+        # (block_hash, nonce-or-None) -> per-layer vectors. nonce=None is the
+        # per-block scheme (one draw shared by every nonce of the block); an int
+        # nonce is the per-nonce scheme (each nonce gets its own draw).
+        self._hash_cache: dict[tuple, list] = {}
+        self._last_refl_key: tuple | None = None    # skip redundant per-step rescatter
         # seeded-routing (MANDATORY for MoE; filled by attach_native_poc): per-MoE-layer
         # PER-ROW forced router-logits buffer [max_tokens, n_experts] + (n_experts,
         # top_k). Static shape -> cudagraph-safe; refreshed IN PLACE each step from
@@ -195,43 +198,70 @@ class PoCNativeState:
         self.embeds[:n].copy_(row_embeds)
         _assert_replicated_across_tp(self.embeds[:n], "embeds")
 
-    def _vectors_for(self, block_hash: str) -> list:
-        """Per-layer reflection vectors for a block_hash (cached across forwards)."""
-        vs = self._hash_cache.get(block_hash)
+    # Device-side cache bound: per-nonce seeding adds one entry per (block_hash,
+    # nonce), so a 128-nonce round is ~128 entries. Entries are stored in the
+    # reflection-buffer dtype (num_layers x hidden, fp16/bf16 -> e.g. ~0.75 MB
+    # for 94 x 4096), so the cap bounds the cache at ~200 MB worst case — memory
+    # allocated AFTER vLLM's startup profiling, so it must stay small. Clear
+    # wholesale past the cap (regeneration is cheap, seeded host murmur).
+    _HASH_CACHE_MAX = 256
+
+    def _vectors_for(self, block_hash: str, nonce: int | None = None) -> list:
+        """Per-layer reflection vectors for (block_hash, nonce) (cached across
+        forwards). nonce=None -> the per-block seed (production default); an int
+        nonce -> that nonce's own seed, so every nonce reflects with an
+        independent draw."""
+        key = (block_hash, nonce)
+        vs = self._hash_cache.get(key)
         if vs is None:
+            if len(self._hash_cache) >= self._HASH_CACHE_MAX:
+                self._hash_cache.clear()
+            suffix = ("" if nonce is None else f"_nonce{nonce}")
+            # Cache in the buffer dtype: halves the footprint vs the generator's
+            # fp32 and matches what the scatter writes (copy_ casts identically).
+            dt = self.vectors[0].dtype
             vs = [
                 generate_householder_vector(
-                    f"{block_hash}_layer_{i}_householder",
-                    self.hidden_size, self.device)
+                    f"{block_hash}{suffix}_layer_{i}_householder",
+                    self.hidden_size, self.device).to(dt)
                 for i in range(self.num_layers)
             ]
-            self._hash_cache[block_hash] = vs
+            self._hash_cache[key] = vs
         return vs
 
-    def set_row_block_hashes(self, row_hashes: list) -> None:
+    def set_row_block_hashes(self, row_hashes: list,
+                             row_refl_nonces: list | None = None) -> None:
         """Write each row's reflection vectors from ITS OWN block_hash (in place),
         so requests with different block_hashes coexist in one forward. row_hashes[i]
         = block_hash for row i, or None (left zero; masked out). Generation of the
-        vectors is cached per block_hash; the scatter is cheap CPU-side setup.
+        vectors is cached per (block_hash, nonce); the scatter is cheap CPU-side setup.
 
-        The reflection vectors depend only on block_hash (not the decode step), so for
-        a stable batch the row->hash mapping is unchanged across all decode steps. Skip
-        the zero + per-(row,layer) copy_ (num_layers x B kernels) when row_hashes
+        row_refl_nonces[i] (optional) = the row's nonce when its request runs
+        per-nonce reflection seeding, else None (per-block seed, the default —
+        omitting the argument reproduces the legacy behavior bit-exactly).
+
+        The reflection vectors do not depend on the decode step, so for a stable
+        batch the row->seed mapping is unchanged across all decode steps. Skip
+        the zero + per-(row,layer) copy_ (num_layers x B kernels) when the mapping
         matches the last call; the buffers already hold the right values."""
-        if row_hashes == self._last_row_hashes:
+        if row_refl_nonces is None:
+            row_refl_nonces = [None] * len(row_hashes)
+        refl_key = (tuple(row_hashes), tuple(row_refl_nonces))
+        if refl_key == self._last_refl_key:
             return
         for buf in self.vectors:
             buf.zero_()
-        for row, bh in enumerate(row_hashes):
+        for row, (bh, nz) in enumerate(zip(row_hashes, row_refl_nonces)):
             if bh is None:
                 continue
-            vs = self._vectors_for(bh)
+            vs = self._vectors_for(bh, nz)
             for i, buf in enumerate(self.vectors):
                 buf[row].copy_(vs[i].to(buf.dtype))
-        self._last_row_hashes = list(row_hashes)
+        self._last_refl_key = refl_key
         _assert_replicated_across_tp(self.vectors[0], "reflection_vectors[0]")
-        # (reflection vectors depend only on block_hash; routing also depends on
-        # nonce+step so it is refreshed separately, per step, via set_routing.)
+        # (reflection vectors depend on block_hash [+ nonce when per-nonce seeded],
+        # never the step; routing also depends on step so it is refreshed
+        # separately, per step, via set_routing.)
 
     def set_routing(self, row_hashes, row_nonces, row_steps) -> None:
         """Refresh PER-ROW seeded router logits — MANDATORY for MoE. EFFICIENT (the

--- a/vllm/poc/poc_params.py
+++ b/vllm/poc/poc_params.py
@@ -26,6 +26,13 @@ class PoCParams:
     enforced_k_steps: Optional[List[int]] = field(default=None, repr=False)
     # Debug mode: collect per-step sphere indices and values for mismatch analysis.
     debug: bool = False
+    # Per-nonce Householder seeding: reflection vectors are seeded by
+    # (block_hash, nonce) instead of block_hash alone, so every nonce measures
+    # with its own independent draw (block statistics average over n independent
+    # instruments instead of sharing one). Forward-affecting: the prover and the
+    # validator MUST use the same value for a nonce or their chains diverge —
+    # which is why this is a per-request parameter, never an env toggle.
+    per_nonce_reflection: bool = False
 
     @property
     def is_validation(self) -> bool:
@@ -46,6 +53,7 @@ class PoCParams:
                 if self.enforced_k_steps is not None else None
             ),
             debug=self.debug,
+            per_nonce_reflection=self.per_nonce_reflection,
         )
 
     def __post_init__(self):

--- a/vllm/poc/routes.py
+++ b/vllm/poc/routes.py
@@ -568,6 +568,10 @@ async def generate(request: Request, body: PoCGenerateRequest) -> dict:
     return {
         "status": "completed",
         "request_id": str(uuid.uuid4()),
+        # debug: expose the validator's own artifacts (incl. sph_values_steps) so a
+        # client can pair them with the prover's for offline vector-channel analysis;
+        # verdict-only response otherwise (unchanged).
+        "artifacts": computed_artifacts if body.debug else [],
         **validation_result,
     }
 

--- a/vllm/poc/routes.py
+++ b/vllm/poc/routes.py
@@ -123,6 +123,10 @@ class PoCGenerateRequest(BaseModel):
     poc_stronger_rng: bool = False
     enforced_k_steps: Optional[Dict[int, List[int]]] = None
     debug: bool = False
+    # Per-nonce Householder seeding (see PoCParams.per_nonce_reflection).
+    # Forward-affecting: a validation request MUST carry the same value the
+    # reference artifacts were generated with, or every chain diverges.
+    per_nonce_reflection: bool = False
 
 
 # =============================================================================
@@ -252,6 +256,7 @@ async def _compute_artifacts_chunk(
     max_tokens: int = 0,
     enforced_k_steps: Optional[Dict[int, List[int]]] = None,
     debug: bool = False,
+    per_nonce_reflection: bool = False,
     timeout_sec: float = POC_GENERATE_CHUNK_TIMEOUT_SEC,
     check_cancelled: Optional[callable] = None,
     block_height: int = 0,
@@ -272,6 +277,7 @@ async def _compute_artifacts_chunk(
         max_tokens=max_tokens,
         enforced_k_steps=enforced_k_steps,
         debug=debug,
+        per_nonce_reflection=per_nonce_reflection,
     )
 
 
@@ -487,6 +493,7 @@ async def generate(request: Request, body: PoCGenerateRequest) -> dict:
             max_tokens=body.params.max_tokens,
             enforced_k_steps=body.enforced_k_steps,
             debug=body.debug,
+            per_nonce_reflection=body.per_nonce_reflection,
             validation_artifacts=validation_map,
             ref_vectors=ref_vectors,
             stat_test_dist_threshold=stat_test.dist_threshold,
@@ -540,6 +547,7 @@ async def generate(request: Request, body: PoCGenerateRequest) -> dict:
                 max_tokens=body.params.max_tokens,
                 enforced_k_steps=chunk_inference_steps,
                 debug=body.debug,
+                per_nonce_reflection=body.per_nonce_reflection,
                 timeout_sec=POC_GENERATE_CHUNK_TIMEOUT_SEC,
                 check_cancelled=check_cancelled,
                 block_height=body.block_height,

--- a/vllm/poc/routes.py
+++ b/vllm/poc/routes.py
@@ -340,7 +340,8 @@ async def _generation_loop(
 
             if artifacts and callback_sender:
                 artifact_objs = [Artifact(nonce=a["nonce"], vector_b64=a["vector_b64"],
-                                          k_points_steps=a.get("k_points_steps"))
+                                          k_points_steps=a.get("k_points_steps"),
+                                          sph_values_steps=a.get("sph_values_steps"))
                                  for a in artifacts]
                 callback_sender.add_artifacts(artifact_objs, {
                     "public_key": config["public_key"],
@@ -443,11 +444,16 @@ async def init_generate(request: Request, body: PoCInitGenerateRequest) -> dict:
 
 @router.post("/generate")
 async def generate(request: Request, body: PoCGenerateRequest) -> dict:
-    # Summarize validation in the log: with debug refs its artifacts carry
+    # Summarize validation in the log: with debug or poc_vector_artifacts
+    # refs its artifacts carry
     # per-step sph_values_steps (multi-MB) — never dump the body wholesale.
     val_log = (f"validation[{len(body.validation.artifacts)} artifacts]"
                if body.validation else None)
-    logger.info(f"PoC /generate: {body.block_hash}, {body.block_height}, {body.public_key}, {body.node_id}, {body.node_count}, {body.nonces}, {body.params}, {body.batch_size}, {body.wait}, {body.url}, {val_log}, {body.stat_test}, {body.poc_stronger_rng}")
+    logger.info(
+        f"PoC /generate: {body.block_hash}, {body.block_height}, "
+        f"{body.public_key}, {body.node_id}, {body.node_count}, {body.nonces}, "
+        f"{body.params}, {body.batch_size}, {body.wait}, {body.url}, "
+        f"{val_log}, {body.stat_test}, {body.poc_stronger_rng}")
     check_params_match(request, body.params)
     engine_client = await get_engine_client(request)
 
@@ -459,7 +465,8 @@ async def generate(request: Request, body: PoCGenerateRequest) -> dict:
             raise HTTPException(status_code=400, detail="validation.artifacts nonces must match nonces field")
     
     validation_map = {a.nonce: a.vector_b64 for a in body.validation.artifacts} if body.validation else None
-    # prover-side pre-snap slices (when the reference was generated with debug):
+    # prover-side pre-snap slices (reference generated with debug or
+    # poc_vector_artifacts):
     # lets run_validation attach the continuous vector-channel score as evidence.
     ref_vectors = {a.nonce: a.sph_values_steps for a in body.validation.artifacts
                    if a.sph_values_steps} if body.validation else None

--- a/vllm/poc/routes.py
+++ b/vllm/poc/routes.py
@@ -437,7 +437,11 @@ async def init_generate(request: Request, body: PoCInitGenerateRequest) -> dict:
 
 @router.post("/generate")
 async def generate(request: Request, body: PoCGenerateRequest) -> dict:
-    logger.info(f"PoC /generate: {body.block_hash}, {body.block_height}, {body.public_key}, {body.node_id}, {body.node_count}, {body.nonces}, {body.params}, {body.batch_size}, {body.wait}, {body.url}, {body.validation}, {body.stat_test}, {body.poc_stronger_rng}")
+    # Summarize validation in the log: with debug refs its artifacts carry
+    # per-step sph_values_steps (multi-MB) — never dump the body wholesale.
+    val_log = (f"validation[{len(body.validation.artifacts)} artifacts]"
+               if body.validation else None)
+    logger.info(f"PoC /generate: {body.block_hash}, {body.block_height}, {body.public_key}, {body.node_id}, {body.node_count}, {body.nonces}, {body.params}, {body.batch_size}, {body.wait}, {body.url}, {val_log}, {body.stat_test}, {body.poc_stronger_rng}")
     check_params_match(request, body.params)
     engine_client = await get_engine_client(request)
 
@@ -449,6 +453,10 @@ async def generate(request: Request, body: PoCGenerateRequest) -> dict:
             raise HTTPException(status_code=400, detail="validation.artifacts nonces must match nonces field")
     
     validation_map = {a.nonce: a.vector_b64 for a in body.validation.artifacts} if body.validation else None
+    # prover-side pre-snap slices (when the reference was generated with debug):
+    # lets run_validation attach the continuous vector-channel score as evidence.
+    ref_vectors = {a.nonce: a.sph_values_steps for a in body.validation.artifacts
+                   if a.sph_values_steps} if body.validation else None
     stat_test = body.stat_test or StatTestModel()
     
     if not body.wait:
@@ -480,6 +488,7 @@ async def generate(request: Request, body: PoCGenerateRequest) -> dict:
             enforced_k_steps=body.enforced_k_steps,
             debug=body.debug,
             validation_artifacts=validation_map,
+            ref_vectors=ref_vectors,
             stat_test_dist_threshold=stat_test.dist_threshold,
             stat_test_p_mismatch=stat_test.p_mismatch,
             stat_test_fraud_threshold=stat_test.fraud_threshold,
@@ -563,6 +572,7 @@ async def generate(request: Request, body: PoCGenerateRequest) -> dict:
         # decode flow (max_tokens>0) → count sphere_k mismatches vs p_mismatch;
         # prefill flow → vector-L2 + binomial (unchanged). Same response shape.
         use_trajectory=body.params.max_tokens > 0,
+        ref_vectors=ref_vectors,
     )
 
     return {

--- a/vllm/poc/validation.py
+++ b/vllm/poc/validation.py
@@ -1,9 +1,62 @@
 """PoC artifact validation logic."""
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
 from .data import decode_vector, fraud_test, DEFAULT_DIST_THRESHOLD, DEFAULT_P_MISMATCH, DEFAULT_FRAUD_THRESHOLD
+
+
+def score_vector_channel(
+    computed_artifacts: List[Dict],
+    ref_vectors: Dict[int, List[str]],
+) -> Optional[Dict]:
+    """Continuous vector-channel score: per-step cosine distance between the
+    prover's pre-snap sphere slices (``sph_values_steps`` from the reference
+    artifacts) and the validator's own teacher-forced recompute.
+
+    The snap keeps ~4 bits/step, so a subtle fraud sits a few pp above the
+    honest cross-HW flip floor; the pre-snap slices carry the displacement
+    field the snap discards (A100 pilot: fraud/floor 60x, no per-nonce
+    overlap). The k-id chain and the k-based verdict are untouched — this is
+    evidence, scored by ONE validator.
+
+    Scores decode steps only (index 0 = prefill, which has its own legacy
+    vector_b64 path); non-finite slices are skipped like the NaN guard.
+    Returns None when no (computed, reference) vector pair exists, so callers
+    attach it as optional evidence.
+    """
+    per_nonce: List[Dict] = []
+    for a in computed_artifacts:
+        ref_b64 = ref_vectors.get(a["nonce"]) or []
+        own_b64 = a.get("sph_values_steps") or []
+        n = min(len(ref_b64), len(own_b64))
+        if n < 2:      # need at least one decode step beyond the prefill slice
+            continue
+        dists = []
+        n_bad = 0
+        for t in range(1, n):
+            vp = decode_vector(ref_b64[t])
+            vv = decode_vector(own_b64[t])
+            if vp.shape != vv.shape or not (
+                    np.all(np.isfinite(vp)) and np.all(np.isfinite(vv))):
+                n_bad += 1
+                continue
+            dists.append(1.0 - float(np.dot(vp, vv)))
+        if dists:
+            per_nonce.append({
+                "nonce": a["nonce"],
+                "mean_dist": float(np.mean(dists)),
+                "n_steps_scored": len(dists),
+                "n_bad_steps": n_bad,
+            })
+    if not per_nonce:
+        return None
+    return {
+        "mean_dist": float(np.mean([e["mean_dist"] for e in per_nonce])),
+        "max_nonce_dist": float(max(e["mean_dist"] for e in per_nonce)),
+        "n_nonces_scored": len(per_nonce),
+        "per_nonce": per_nonce,
+    }
 
 
 def validate_artifacts(
@@ -63,6 +116,7 @@ def run_validation(
     fraud_threshold: float = DEFAULT_FRAUD_THRESHOLD,
     k_dim: int = 12,
     use_trajectory: bool = False,
+    ref_vectors: Optional[Dict[int, List[str]]] = None,
 ) -> Dict:
     """Run full validation with fraud test. Same response shape for both flows.
 
@@ -72,6 +126,10 @@ def run_validation(
       all steps; fraud when the mismatch rate exceeds p_mismatch (reused as the max
       allowed fraction). No binomial; p_value carries the rate but the decision
       ignores it.
+    - ref_vectors (optional, decode): prover-side sph_values_steps per nonce.
+      When both sides carry pre-snap slices, the continuous vector-channel score
+      (score_vector_channel) is attached as ``vector_score`` EVIDENCE — the
+      verdict stays k-based so the two channels can be A/B'd on the same run.
     """
     per_nonce: List[Dict] = []   # per-nonce evidence: [{nonce, n_sphere_mismatches, n_steps}]
     if use_trajectory:
@@ -99,7 +157,7 @@ def run_validation(
         )
         p_value, fraud_detected = fraud_test(n_mismatch, n_total, p_mismatch, fraud_threshold)
 
-    return {
+    result = {
         "n_total": n_total,
         "n_mismatch": n_mismatch,
         "mismatch_nonces": mismatch_nonces,
@@ -107,3 +165,8 @@ def run_validation(
         "p_value": p_value,
         "fraud_detected": fraud_detected,
     }
+    if use_trajectory and ref_vectors:
+        vector_score = score_vector_channel(computed_artifacts, ref_vectors)
+        if vector_score is not None:
+            result["vector_score"] = vector_score
+    return result

--- a/vllm/poc/validation.py
+++ b/vllm/poc/validation.py
@@ -3,7 +3,11 @@ from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
+from vllm.logger import init_logger
+
 from .data import decode_vector, fraud_test, DEFAULT_DIST_THRESHOLD, DEFAULT_P_MISMATCH, DEFAULT_FRAUD_THRESHOLD
+
+logger = init_logger(__name__)
 
 
 def score_vector_channel(
@@ -24,24 +28,39 @@ def score_vector_channel(
     vector_b64 path); non-finite slices are skipped like the NaN guard.
     Returns None when no (computed, reference) vector pair exists, so callers
     attach it as optional evidence.
+
+    Dim-adaptive: the two sides may ship different dims/steps (windowed
+    poc_vector_artifacts slices are raw, not renormalized) — both are
+    truncated to the common leading dims and renormalized before the cosine.
     """
     per_nonce: List[Dict] = []
+    n_skipped = 0      # nonces with a ref but nothing scorable (all-bad/short)
+    n_bad_total = 0
     for a in computed_artifacts:
         ref_b64 = ref_vectors.get(a["nonce"]) or []
         own_b64 = a.get("sph_values_steps") or []
         n = min(len(ref_b64), len(own_b64))
         if n < 2:      # need at least one decode step beyond the prefill slice
+            n_skipped += bool(ref_b64)
             continue
         dists = []
         n_bad = 0
         for t in range(1, n):
             vp = decode_vector(ref_b64[t])
             vv = decode_vector(own_b64[t])
-            if vp.shape != vv.shape or not (
+            d = min(vp.shape[0], vv.shape[0])
+            vp, vv = vp[:d], vv[:d]
+            if d == 0 or not (
                     np.all(np.isfinite(vp)) and np.all(np.isfinite(vv))):
                 n_bad += 1
                 continue
-            dists.append(1.0 - float(np.dot(vp, vv)))
+            np_norm = float(np.linalg.norm(vp))
+            nv_norm = float(np.linalg.norm(vv))
+            if np_norm == 0.0 or nv_norm == 0.0:
+                n_bad += 1
+                continue
+            dists.append(1.0 - float(np.dot(vp, vv)) / (np_norm * nv_norm))
+        n_bad_total += n_bad
         if dists:
             per_nonce.append({
                 "nonce": a["nonce"],
@@ -49,12 +68,16 @@ def score_vector_channel(
                 "n_steps_scored": len(dists),
                 "n_bad_steps": n_bad,
             })
+        else:
+            n_skipped += 1     # every step bad — adversarial NaN/zero slices land here
     if not per_nonce:
         return None
     return {
         "mean_dist": float(np.mean([e["mean_dist"] for e in per_nonce])),
         "max_nonce_dist": float(max(e["mean_dist"] for e in per_nonce)),
         "n_nonces_scored": len(per_nonce),
+        "n_nonces_skipped": n_skipped,
+        "n_bad_steps_total": n_bad_total,
         "per_nonce": per_nonce,
     }
 
@@ -169,4 +192,10 @@ def run_validation(
         vector_score = score_vector_channel(computed_artifacts, ref_vectors)
         if vector_score is not None:
             result["vector_score"] = vector_score
+        else:
+            # never silent: an adversary shipping all-bad slices (or a
+            # misconfigured pair) must not look like "channel not requested"
+            logger.warning(
+                "vector channel: %d reference trajectories supplied but no "
+                "(computed, reference) pair scored", len(ref_vectors))
     return result

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -134,10 +134,13 @@ class PoCOutput:
     # FAULT (GPU contention / kernel fault), NOT fraud. Excluded from
     # n_sphere_mismatches; >0 means the trajectory is suspect and should be re-run.
     n_nan_steps: int = 0
-    # Debug mode (debug=True in request): per-step sphere slice indices and
-    # values.  Index 0 = prefill, 1..N = decode steps.
-    # sph_indices_steps[step] : list of SPHERE_DIM int indices into hidden state
-    # sph_values_steps[step]  : base64-encoded float16 array of gathered values
+    # Per-step sphere slices, index 0 = prefill, 1..N = decode steps. Emitted
+    # under debug (full trajectory, full SPHERE_DIM) or poc_vector_artifacts
+    # (prefill + leading window, leading poc_vector_artifact_dim coords).
+    # sph_indices_steps[step] : list of SPHERE_DIM int indices (debug only)
+    # sph_values_steps[step]  : base64 fp16-LE pre-snap slice — a raw slice of
+    #                           a unit vector, NOT unit itself; renormalize
+    #                           before any cosine.
     sph_indices_steps: list[list[int]] = field(default_factory=list)
     sph_values_steps: list[str] = field(default_factory=list)
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4172,9 +4172,13 @@ class GPUModelRunner(
                         row_hashes = [None] * n_rows
                         row_nonces = [0] * n_rows           # per-row nonce + step for
                         row_steps = [0] * n_rows            # MANDATORY seeded-routing
+                        # Reflection-seed nonce per row: the request's nonce when it
+                        # runs per-nonce reflection seeding, else None (per-block).
+                        row_refl_nonces = [None] * n_rows
                         for meta in poc_metadata:
-                            bh = meta['poc_params'].block_hash
-                            nz = meta['poc_params'].nonce
+                            pp = meta['poc_params']
+                            bh = pp.block_hash
+                            nz = pp.nonce
                             stp = meta.get('decode_step', 0)
                             s = meta['start_idx']
                             for r in range(s, s + meta['length']):
@@ -4182,7 +4186,10 @@ class GPUModelRunner(
                                     row_hashes[r] = bh
                                     row_nonces[r] = nz
                                     row_steps[r] = stp
-                        self._poc_native.set_row_block_hashes(row_hashes)
+                                    if pp.per_nonce_reflection:
+                                        row_refl_nonces[r] = nz
+                        self._poc_native.set_row_block_hashes(
+                            row_hashes, row_refl_nonces)
                         # Seeded routing (mandatory for MoE): refresh per-row forced
                         # experts from (block_hash,nonce,step,layer). Cached base +
                         # on-GPU step fold -> cudagraph-safe, no per-step host sync.


### PR DESCRIPTION
As agreed: extend the artifacts, keep the verdict untouched. A config flag ships compact
pre-snap vector slices next to the k-ids; the validator attaches a continuous
`vector_score` as evidence.

- `a2a3a6f` — emit the documented `sph_values_steps` debug contract on the decode path.
- `6df0b19` — `score_vector_channel()`: per-step cosine distance, per-nonce mean → `vector_score` (evidence only).
- `4620686` — `collect.py --debug`, offline analyzer, unit tests.
- `556ed29` — per-nonce reflection seeding (opt-in, request-scoped; null on aggregates, zero default impact).
- `bf5d74d` — unblock FLASH_ATTN on B300/sm_103 (vendored cutlass enum bug in the cute-FA arch gate).
- `2f38a0b` — **`poc_vector_artifacts` config flag**: production artifacts (no `--debug`)
  carry the prefill point + first `poc_vector_artifact_steps` decode steps, truncated to
  `poc_vector_artifact_dim` leading coordinates (raw slice; scorer renormalizes,
  dim-adaptive). Emission only; flags in `CacheConfig`, excluded from the compile-cache key.

## Proposed defaults (measured: 2 campaigns + 128-nonce fresh-seed verification; worst case = honest B300/TRITON → validator 4×A100/FA vs AWQ)

| knob | value | measured basis |
|---|---|---|
| `poc_vector_artifact_steps` | 64 | power @ FPR 1e-4 = 1.000 at T=8–128, decays to 0.45–0.74 at T=256 (honest cross-kernel drift compounds with depth; fraud is full-size from step 1) |
| `poc_vector_artifact_dim` | 32 | D=16…256 indistinguishable at T≤64 (incl. attenuated fraud, α₅₀≈0.9 for all) |
| block statistic | median of per-nonce means | honest per-nonce tail is heavy (outliers 10× mean); mean leaks FPR |
| threshold | empirical quantile on honest traffic | gaussian μ+kσ under-covers (realized FPR up to 13× nominal); empirical FPR-1e-4 → power 0.998, out-of-sample 1.000 |

Wire: 65 × 32 × f16 ≈ 4.2 KB/nonce (~180 KB per 32-nonce block) vs ~4 MB full debug.
Vs discrete at its optimum (T=256, thr 0.092): power 1.000 vs 0.93 on real AWQ;
attenuated-fraud floor 0.85× vs 0.95–1.10× AWQ amplitude.

## Ops notes for per-model thresholds

1. `p_mismatch=0.10` passes ~55% of real AWQ blocks in the worst case; calibrated value here = 0.092. Fraud excess compresses −36…−48% across contexts — recalibration needed per context.
2. Margin gate: τ=0.005 erases 57.6% of fraud mismatches (power 0.94→0.78); τ≤0.002 keeps power.
3. Floors are environment-fragile: installing `deep_gemm` on the prover box moved the honest cross-kernel floor +45% (E8M0 path, no config change). Consider shipping a numeric-path fingerprint with artifacts.
4. seq_len=256 prefill is a cross-HW anchor: at seq_len=8 nothing separates (honest floor above fraud in both channels).